### PR TITLE
Feat: handle infinite waits for websockets

### DIFF
--- a/dom/src/main/scala/org/http4s/dom/WSClient.scala
+++ b/dom/src/main/scala/org/http4s/dom/WSClient.scala
@@ -37,6 +37,7 @@ import scodec.bits.ByteVector
 
 import scala.scalajs.js
 
+import scala.concurrent.duration._
 final class WSException private[dom] (
     private[dom] val reason: String
 ) extends RuntimeException(reason)
@@ -110,7 +111,7 @@ object WSClient {
                 case Some(reason) => ws.close(1000, reason)
                 case None => ws.close(1000)
               }
-            }.flatMap(close.complete(_)) *> messages.offer(None)
+            }.flatMap(close.complete(_)).timeout(5.seconds).attempt.void
         }
       } yield new WSConnection[F] {
 


### PR DESCRIPTION
This PR closes #1 

This PR adds a timeout to the close event to prevent the program from waiting infinitely for the websocket to close.